### PR TITLE
Add custom system prompt dialog

### DIFF
--- a/app/(chat)/api/chat/route.ts
+++ b/app/(chat)/api/chat/route.ts
@@ -16,6 +16,7 @@ import {
   getStreamIdsByChatId,
   saveChat,
   saveMessages,
+  getSystemPromptByUserId,
 } from '@/lib/db/queries';
 import { generateUUID, getTrailingMessageId } from '@/lib/utils';
 import { generateTitleFromUserMessage } from '../../actions';
@@ -128,6 +129,11 @@ export async function POST(request: Request) {
       country,
     };
 
+    const userPromptRecord = await getSystemPromptByUserId({
+      userId: session.user.id,
+    });
+    const customSystemPrompt = userPromptRecord?.prompt;
+
     await saveMessages({
       messages: [
         {
@@ -148,7 +154,11 @@ export async function POST(request: Request) {
       execute: (dataStream) => {
         const result = streamText({
           model: myProvider.languageModel(selectedChatModel),
-          system: systemPrompt({ selectedChatModel, requestHints }),
+          system: systemPrompt({
+            selectedChatModel,
+            requestHints,
+            customPrompt: customSystemPrompt,
+          }),
           messages,
           maxSteps: 5,
           experimental_activeTools:

--- a/app/(chat)/api/system-prompt/route.ts
+++ b/app/(chat)/api/system-prompt/route.ts
@@ -1,0 +1,38 @@
+import { auth } from '@/app/(auth)/auth';
+import { getSystemPromptByUserId, upsertSystemPrompt } from '@/lib/db/queries';
+import { ChatSDKError } from '@/lib/errors';
+
+export async function GET() {
+  const session = await auth();
+
+  if (!session?.user) {
+    return new ChatSDKError('unauthorized:api').toResponse();
+  }
+
+  const prompt = await getSystemPromptByUserId({ userId: session.user.id });
+
+  return Response.json({ prompt: prompt?.prompt ?? '' });
+}
+
+export async function POST(request: Request) {
+  const session = await auth();
+
+  if (!session?.user) {
+    return new ChatSDKError('unauthorized:api').toResponse();
+  }
+
+  let body: { prompt?: string };
+  try {
+    body = await request.json();
+  } catch {
+    return new ChatSDKError('bad_request:api').toResponse();
+  }
+
+  if (typeof body.prompt !== 'string') {
+    return new ChatSDKError('bad_request:api').toResponse();
+  }
+
+  await upsertSystemPrompt({ userId: session.user.id, prompt: body.prompt });
+
+  return Response.json({ success: true });
+}

--- a/components/sidebar-user-nav.tsx
+++ b/components/sidebar-user-nav.tsx
@@ -3,6 +3,7 @@
 import { ChevronUp } from 'lucide-react';
 import Image from 'next/image';
 import type { User } from '@/app/(auth)/auth';
+import { useState } from 'react';
 import { useTheme } from 'next-themes';
 
 import {
@@ -16,9 +17,11 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
 } from '@/components/ui/sidebar';
+import { SystemPromptDialog } from './system-prompt-dialog';
 
 export function SidebarUserNav({ user }: { user: User }) {
   const { setTheme, resolvedTheme } = useTheme();
+  const [showPromptDialog, setShowPromptDialog] = useState(false);
 
   return (
     <SidebarMenu>
@@ -50,13 +53,25 @@ export function SidebarUserNav({ user }: { user: User }) {
             <DropdownMenuItem
               data-testid="user-nav-item-theme"
               className="cursor-pointer"
-              onSelect={() => setTheme(resolvedTheme === 'dark' ? 'light' : 'dark')}
+              onSelect={() =>
+                setTheme(resolvedTheme === 'dark' ? 'light' : 'dark')
+              }
             >
               {`Toggle ${resolvedTheme === 'light' ? 'dark' : 'light'} mode`}
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              className="cursor-pointer"
+              onSelect={() => setShowPromptDialog(true)}
+            >
+              Custom system prompt
             </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>
       </SidebarMenuItem>
+      <SystemPromptDialog
+        open={showPromptDialog}
+        onOpenChange={setShowPromptDialog}
+      />
     </SidebarMenu>
   );
 }

--- a/components/system-prompt-dialog.tsx
+++ b/components/system-prompt-dialog.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogCancel,
+  AlertDialogAction,
+} from '@/components/ui/alert-dialog';
+import { Textarea } from '@/components/ui/textarea';
+import { toast } from '@/components/toast';
+
+export function SystemPromptDialog({
+  open,
+  onOpenChange,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const [prompt, setPrompt] = useState('');
+
+  useEffect(() => {
+    if (open) {
+      fetch('/api/system-prompt')
+        .then(async (res) => {
+          const data = await res.json();
+          setPrompt(data.prompt || '');
+        })
+        .catch(() => {
+          toast({ type: 'error', message: 'Failed to load system prompt' });
+        });
+    }
+  }, [open]);
+
+  const handleSave = async () => {
+    const res = await fetch('/api/system-prompt', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ prompt }),
+    });
+
+    if (res.ok) {
+      toast({ type: 'success', message: 'System prompt updated' });
+      onOpenChange(false);
+    } else {
+      toast({ type: 'error', message: 'Failed to update system prompt' });
+    }
+  };
+
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent className="space-y-4">
+        <AlertDialogHeader>
+          <AlertDialogTitle>Custom system prompt</AlertDialogTitle>
+        </AlertDialogHeader>
+        <Textarea
+          value={prompt}
+          onChange={(e) => setPrompt(e.target.value)}
+          className="min-h-[120px]"
+        />
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction onClick={handleSave}>Save</AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/lib/ai/prompts.ts
+++ b/lib/ai/prompts.ts
@@ -53,16 +53,19 @@ About the origin of user's request:
 export const systemPrompt = ({
   selectedChatModel,
   requestHints,
+  customPrompt,
 }: {
   selectedChatModel: string;
   requestHints: RequestHints;
+  customPrompt?: string;
 }) => {
   const requestPrompt = getRequestPromptFromHints(requestHints);
+  const basePrompt = customPrompt ?? regularPrompt;
 
   if (selectedChatModel === 'chat-model-reasoning') {
-    return `${regularPrompt}\n\n${requestPrompt}`;
+    return `${basePrompt}\n\n${requestPrompt}`;
   } else {
-    return `${regularPrompt}\n\n${requestPrompt}\n\n${artifactsPrompt}`;
+    return `${basePrompt}\n\n${requestPrompt}\n\n${artifactsPrompt}`;
   }
 };
 

--- a/lib/db/migrations/0007_custom_system_prompt.sql
+++ b/lib/db/migrations/0007_custom_system_prompt.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS "SystemPrompt" (
+        "id" uuid DEFAULT gen_random_uuid() NOT NULL,
+        "userId" uuid NOT NULL,
+        "prompt" text NOT NULL,
+        CONSTRAINT "SystemPrompt_id_pk" PRIMARY KEY("id")
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "SystemPrompt" ADD CONSTRAINT "SystemPrompt_userId_User_id_fk" FOREIGN KEY ("userId") REFERENCES "public"."User"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -129,3 +129,19 @@ export const stream = pgTable(
 );
 
 export type Stream = InferSelectModel<typeof stream>;
+
+export const systemPromptTable = pgTable(
+  'SystemPrompt',
+  {
+    id: uuid('id').defaultRandom().notNull(),
+    userId: uuid('userId')
+      .notNull()
+      .references(() => user.id),
+    prompt: text('prompt').notNull(),
+  },
+  (table) => ({
+    pk: primaryKey({ columns: [table.id] }),
+  }),
+);
+
+export type SystemPrompt = InferSelectModel<typeof systemPromptTable>;


### PR DESCRIPTION
## Summary
- create API route for reading and updating user system prompt
- extend database schema and queries to store per-user prompts
- allow `systemPrompt()` to accept custom prompt
- fetch and use custom prompt in chat API
- add `SystemPromptDialog` UI component
- hook it to sidebar user menu
- add DB migration

## Testing
- `pnpm exec biome format --write app/(chat)/api/chat/route.ts app/(chat)/api/system-prompt/route.ts components/sidebar-user-nav.tsx components/system-prompt-dialog.tsx lib/ai/prompts.ts lib/db/queries.ts lib/db/schema.ts lib/db/migrations/0007_custom_system_prompt.sql`
- `pnpm exec biome lint --write --unsafe app/(chat)/api/chat/route.ts app/(chat)/api/system-prompt/route.ts components/sidebar-user-nav.tsx components/system-prompt-dialog.tsx lib/ai/prompts.ts lib/db/queries.ts lib/db/schema.ts lib/db/migrations/0007_custom_system_prompt.sql`
- `pnpm test` *(fails: Serving HTML report at http://localhost:9323)*

------
https://chatgpt.com/codex/tasks/task_b_6874f14eb0d88330adaead127739135e